### PR TITLE
Implement simple on/off-track detection

### DIFF
--- a/docs/math.js
+++ b/docs/math.js
@@ -133,6 +133,29 @@ var CubicBezier = /** @class */ (function () {
         this.cp1 = cp1;
         this.cp2 = cp2;
     }
+    // The point on the curve at the given t in [0, 1].
+    CubicBezier.prototype.at = function (t) {
+        return this.start.times((1 - t) * (1 - t) * (1 - t))
+            .plus(this.cp1.times(3 * (1 - t) * (1 - t) * t))
+            .plus(this.cp2.times(3 * (1 - t) * t * t))
+            .plus(this.end.times(t * t * t));
+    };
+    // The point on this Bezier curve closest to the given point, based on
+    // sampling. The number of samples must be a positive integer.
+    CubicBezier.prototype.projectPoint = function (p, nSamples) {
+        if (nSamples === void 0) { nSamples = 100; }
+        var minD2 = Infinity;
+        var closest;
+        for (var i = 0; i < nSamples; ++i) {
+            var q = this.at(i / (nSamples - 1));
+            var d2 = q.minus(p).length2();
+            if (d2 < minD2) {
+                minD2 = d2;
+                closest = q;
+            }
+        }
+        return closest;
+    };
     return CubicBezier;
 }());
 export { CubicBezier };

--- a/docs/track.js
+++ b/docs/track.js
@@ -40,18 +40,40 @@ var Track = /** @class */ (function () {
             this.spline.push(new CubicBezier(start, end, cp1, cp2));
         }
     }
+    Track.prototype.containsPoint = function (p) {
+        for (var _i = 0, _a = this.spline; _i < _a.length; _i++) {
+            var curve = _a[_i];
+            if (curve.projectPoint(p).minus(p).length2() < this.radius * this.radius) {
+                return true;
+            }
+        }
+        return false;
+    };
     Track.prototype.drawWorld = function (ctx, debug) {
-        this.drawSplines(ctx, this.radius, "black");
-        this.drawSplines(ctx, this.radius - TRACK_BORDER, "rgb(60, 60, 60)");
+        this.drawSpline(ctx, this.radius, "black");
+        this.drawSpline(ctx, this.radius - TRACK_BORDER, "rgb(60, 60, 60)");
         if (debug) {
-            // Draw Bezier curve "frames".
             ctx.lineWidth = 1;
             var even = true;
             for (var _i = 0, _a = this.spline; _i < _a.length; _i++) {
                 var curve = _a[_i];
+                // Draw some points along the curve.
+                ctx.beginPath();
+                ctx.lineWidth = 1;
+                ctx.strokeStyle = "black";
+                ctx.moveTo(curve.start.x, curve.start.y);
+                var nSamples = 10;
+                for (var i = 0; i < nSamples; ++i) {
+                    var t = i / (nSamples - 1);
+                    var p = curve.at(t);
+                    ctx.lineTo(p.x, p.y);
+                }
+                ctx.stroke();
+                // Draw Bezier curve "frame".
                 ctx.strokeStyle = even ? "red" : "white";
                 even = !even;
                 ctx.beginPath();
+                ctx.lineWidth = 2;
                 ctx.moveTo(curve.start.x, curve.start.y);
                 ctx.lineTo(curve.cp1.x, curve.cp1.y);
                 ctx.lineTo(curve.cp2.x, curve.cp2.y);
@@ -67,7 +89,7 @@ var Track = /** @class */ (function () {
             ctx.fillText(this.name, 10, 30);
         }
     };
-    Track.prototype.drawSplines = function (ctx, radius, style) {
+    Track.prototype.drawSpline = function (ctx, radius, style) {
         ctx.beginPath();
         ctx.lineJoin = "round";
         ctx.strokeStyle = style;

--- a/math.ts
+++ b/math.ts
@@ -174,4 +174,28 @@ export class CubicBezier {
 		this.cp1 = cp1;
 		this.cp2 = cp2;
 	}
+
+	// The point on the curve at the given t in [0, 1].
+	at(t: number): Vec2 {
+		return this.start.times((1 - t) * (1 - t) * (1 - t))
+			.plus(this.cp1.times(3 * (1 - t) * (1 - t) * t))
+			.plus(this.cp2.times(3 * (1 - t) * t * t))
+			.plus(this.end.times(t * t * t));
+	}
+
+	// The point on this Bezier curve closest to the given point, based on
+	// sampling. The number of samples must be a positive integer.
+	projectPoint(p: Vec2, nSamples: number = 100): Vec2 {
+		let minD2 = Infinity;
+		let closest: Vec2;
+		for (let i = 0; i < nSamples; ++i) {
+			const q = this.at(i / (nSamples - 1));
+			const d2 = q.minus(p).length2();
+			if (d2 < minD2) {
+				minD2 = d2;
+				closest = q;
+			}
+		}
+		return closest;
+	}
 }

--- a/track.ts
+++ b/track.ts
@@ -1,4 +1,4 @@
-import { CubicBezier, Vec2 } from "./math.js"
+import { CubicBezier, TAU, Vec2 } from "./math.js"
 
 const TRACK_BORDER = 2.0;
 
@@ -51,18 +51,41 @@ export class Track {
 		}
 	}
 
+	containsPoint(p: Vec2): boolean {
+		for (let curve of this.spline) {
+			if (curve.projectPoint(p).minus(p).length2() < this.radius * this.radius) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	drawWorld(ctx: CanvasRenderingContext2D, debug: boolean) {
-		this.drawSplines(ctx, this.radius, "black");
-		this.drawSplines(ctx, this.radius - TRACK_BORDER, "rgb(60, 60, 60)");
+		this.drawSpline(ctx, this.radius, "black");
+		this.drawSpline(ctx, this.radius - TRACK_BORDER, "rgb(60, 60, 60)");
 
 		if (debug) {
-			// Draw Bezier curve "frames".
 			ctx.lineWidth = 1;
 			let even = true;
 			for (let curve of this.spline) {
+				// Draw some points along the curve.
+				ctx.beginPath();
+				ctx.lineWidth = 1;
+				ctx.strokeStyle = "black";
+				ctx.moveTo(curve.start.x, curve.start.y);
+				const nSamples = 10;
+				for (let i = 0; i < nSamples; ++i) {
+					const t = i / (nSamples - 1);
+					const p = curve.at(t);
+					ctx.lineTo(p.x, p.y);
+				}
+				ctx.stroke();
+
+				// Draw Bezier curve "frame".
 				ctx.strokeStyle = even ? "red" : "white";
 				even = !even;
 				ctx.beginPath();
+				ctx.lineWidth = 2;
 				ctx.moveTo(curve.start.x, curve.start.y);
 				ctx.lineTo(curve.cp1.x, curve.cp1.y);
 				ctx.lineTo(curve.cp2.x, curve.cp2.y);
@@ -80,7 +103,7 @@ export class Track {
 		}
 	}
 
-	private drawSplines(ctx: CanvasRenderingContext2D, radius: number, style: string) {
+	private drawSpline(ctx: CanvasRenderingContext2D, radius: number, style: string) {
 		ctx.beginPath();
 		ctx.lineJoin = "round";
 		ctx.strokeStyle = style;


### PR DESCRIPTION
Unlike the old straight-segment offroad detection, this implementation for cubic spline tracks uses sampling with a fixed number of samples, which is probably okay for now. May want to make the sample count dependent on the (approximate) Bezier curve length in the future.